### PR TITLE
FIX: Windows compatibility issues with Junctions

### DIFF
--- a/internal/smash/configuration.go
+++ b/internal/smash/configuration.go
@@ -12,7 +12,7 @@ import (
 
 func (app *App) printConfiguration() {
 	f := app.Flags
-	log.Println(Bold(Cyan("Configuration")))
+	log.Println(Bold(Cyan("---| Configuration")))
 	log.Println(Bold("Locations:   "), Magenta(strings.Join(app.Locations, ", ")))
 	log.Println(Bold("Algorithm:   "), Magenta(algorithms.Algorithm(f.Algorithm)))
 	log.Println(Bold("Max Workers: "), Magenta(f.MaxWorkers))

--- a/internal/smash/formatter.go
+++ b/internal/smash/formatter.go
@@ -22,6 +22,7 @@ func (app *App) printVerbose(message ...any) {
 
 func (app *App) printSmashHits(cache *haxmap.Map[string, []SmashFile]) uint64 {
 	totalDuplicateSize := uint64(0)
+	log.Println(aurora.Cyan(aurora.Bold("---| Duplicates")))
 	cache.ForEach(func(hash string, files []SmashFile) bool {
 		mainFile := files[0]
 		lastIndex := len(files)
@@ -47,8 +48,13 @@ func (app *App) printSmashHits(cache *haxmap.Map[string, []SmashFile]) uint64 {
 }
 
 func (app *App) printSmashRunSummary(rs RunSummary) {
+	log.Println(aurora.Cyan(aurora.Bold("---| Summary")))
 	log.Println("Total Time:   ", aurora.Green(fmt.Sprintf("%dms", rs.ElapsedTime)))
 	log.Println("Total Files:  ", aurora.Blue(rs.TotalFiles))
 	log.Println("Total Unique: ", aurora.Blue(rs.UniqueFiles))
-	log.Println("Total Duplicates: ", aurora.Blue(rs.DuplicateFiles), "(", aurora.Cyan(rs.DuplicateFileSizeF), " can be reclaimed).")
+	log.Println("Total Duplicates:  ", aurora.Blue(rs.DuplicateFiles))
+	if rs.DuplicateFileSize > 0 {
+		log.Println("Total Reclaimable: ", aurora.Cyan(rs.DuplicateFileSizeF))
+	}
+
 }

--- a/internal/smash/formatter.go
+++ b/internal/smash/formatter.go
@@ -44,6 +44,9 @@ func (app *App) printSmashHits(cache *haxmap.Map[string, []SmashFile]) uint64 {
 		}
 		return true
 	})
+	if cache.Len() == 0 {
+		log.Println(aurora.Green("No duplicates found :-)"))
+	}
 	return totalDuplicateSize
 }
 

--- a/internal/smash/version.go
+++ b/internal/smash/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	Version string = "v0.0.1"
+	Version string = "v0.0.2"
 	Commit  string = "none"
 	Date    string = "unknown"
 	Home    string = "github.com/thushan/smash"

--- a/pkg/slicer/slicer.go
+++ b/pkg/slicer/slicer.go
@@ -3,11 +3,12 @@ package slicer
 import (
 	"encoding/gob"
 	"errors"
-	"github.com/logrusorgru/aurora/v3"
-	"github.com/thushan/smash/internal/algorithms"
 	"io"
 	"io/fs"
 	"log"
+
+	"github.com/logrusorgru/aurora/v3"
+	"github.com/thushan/smash/internal/algorithms"
 )
 
 type Slicer struct {
@@ -61,8 +62,8 @@ func (slicer *Slicer) SliceFS(fs fs.FS, name string, disableSlicing bool) (Slice
 			// Ignore ReadOnly issues.
 			return
 		}
-		if err := fs.Close(); err != nil {
-			log.Println(aurora.Red("ERR"), aurora.Blue(name), err)
+		if ferr := fs.Close(); ferr != nil {
+			log.Println(aurora.Red("ERR"), aurora.Blue(name), ferr)
 		}
 	}(f)
 

--- a/pkg/slicer/slicer.go
+++ b/pkg/slicer/slicer.go
@@ -3,10 +3,11 @@ package slicer
 import (
 	"encoding/gob"
 	"errors"
+	"github.com/logrusorgru/aurora/v3"
+	"github.com/thushan/smash/internal/algorithms"
 	"io"
 	"io/fs"
-
-	"github.com/thushan/smash/internal/algorithms"
+	"log"
 )
 
 type Slicer struct {
@@ -55,7 +56,15 @@ func (slicer *Slicer) SliceFS(fs fs.FS, name string, disableSlicing bool) (Slice
 
 	stats := SlicerStats{Hash: slicer.defaultBytes, Filename: name}
 	f, err := fs.Open(name)
-	defer f.Close()
+	defer func(fs io.Closer) {
+		if fs == nil {
+			// Ignore ReadOnly issues.
+			return
+		}
+		if err := fs.Close(); err != nil {
+			log.Println(aurora.Red("ERR"), aurora.Blue(name), err)
+		}
+	}(f)
 
 	if err != nil {
 		return stats, err


### PR DESCRIPTION
This PR addresses some of the Windows Junction link issues when smashing ones home directory (Eg. `C:\Users\Homer\`) with common paths that are junction pointed now. We'll skip these directories for the moment.

For example `C:\Users\thush\Documents\` folders):
![image](https://github.com/thushan/smash/assets/68254/8fe37e55-f7a6-4f1b-9c42-c7f3742e2255)

`smash` would have trouble following those junctions/symlinksat this stage due to golangs implementation (that may be fixed by [this issue](https://github.com/golang/go/issues/49580)).