### PR TITLE
BREAKING: Implements directory recursion

### DIFF
--- a/docs/vhs/demo-photos-hdd.tape
+++ b/docs/vhs/demo-photos-hdd.tape
@@ -18,7 +18,7 @@ Enter
 Type "# but we want to ignore sort, tmp & events folders in the collection"
 Enter
 Sleep 1s
-Type "./smash /media/thushan/smash/photos/ --exclude-dir=sort,tmp,events -o report.json"
+Type "./smash /media/thushan/smash/photos/ -r --exclude-dir=sort,tmp,events -o report.json"
 Sleep 500ms
 Enter
 Sleep 30s

--- a/docs/vhs/demo.tape
+++ b/docs/vhs/demo.tape
@@ -18,7 +18,7 @@ Enter
 Type "# exlude the git dir and saving to report.json!"
 Enter
 Sleep 1s
-Type "./smash ~/linux/drivers --exclude-dir=git -o report.json"
+Type "./smash ~/linux/drivers -r --exclude-dir=git -o report.json"
 Sleep 500ms
 Enter
 Sleep 10s

--- a/docs/vhs/install.tape
+++ b/docs/vhs/install.tape
@@ -31,7 +31,7 @@ Sleep 500ms
 Enter
 
 # smash Linux/drivers
-Type "smash /linux/drivers
+Type "smash /linux/drivers -r
 Sleep 500ms
 Enter
 Sleep 60s

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -50,6 +50,7 @@ func init() {
 	flags.BoolVarP(&af.IgnoreHidden, "ignore-hidden", "", true, "Ignore hidden files & folders Eg. files/folders starting with '.'")
 	flags.BoolVarP(&af.IgnoreSystem, "ignore-system", "", true, "Ignore system files & folders Eg. '$MFT', '.Trash'")
 	flags.BoolVarP(&af.Silent, "silent", "q", false, "Run in silent mode")
+	flags.BoolVarP(&af.Recurse, "recurse", "r", false, "Recursively search directories for files")
 	flags.BoolVarP(&af.Verbose, "verbose", "", false, "Run in verbose mode")
 	flags.BoolVarP(&af.Profile, "profile", "", false, "Enable Go Profiler - see localhost:1984/debug/pprof")
 	flags.BoolVarP(&af.HideProgress, "no-progress", "", false, "Disable progress updates")

--- a/internal/smash/app.go
+++ b/internal/smash/app.go
@@ -106,6 +106,7 @@ func (app *App) Exec() error {
 	slo := app.Runtime.SlicerOptions
 
 	files := app.Runtime.Files
+	recurse := app.Flags.Recurse
 	locations := app.Locations
 	isVerbose := app.Flags.Verbose && !app.Flags.Silent
 	showProgress := (!app.Flags.HideProgress && !app.Flags.Silent) || isVerbose
@@ -121,7 +122,7 @@ func (app *App) Exec() error {
 		}()
 		for _, location := range locations {
 			psi.UpdateText("Indexing location: " + location)
-			err := wk.WalkDirectory(os.DirFS(location), location, files)
+			err := wk.WalkDirectory(os.DirFS(location), location, recurse, files)
 
 			if err != nil {
 				if isVerbose {

--- a/internal/smash/app.go
+++ b/internal/smash/app.go
@@ -106,9 +106,9 @@ func (app *App) Exec() error {
 	slo := app.Runtime.SlicerOptions
 
 	files := app.Runtime.Files
-	recurse := app.Flags.Recurse
 	locations := app.Locations
 	isVerbose := app.Flags.Verbose && !app.Flags.Silent
+	walkOptions := indexer.WalkConfig{Recurse: app.Flags.Recurse}
 	showProgress := (!app.Flags.HideProgress && !app.Flags.Silent) || isVerbose
 
 	pap := theme.MultiWriter()
@@ -122,7 +122,7 @@ func (app *App) Exec() error {
 		}()
 		for _, location := range locations {
 			psi.UpdateText("Indexing location: " + location)
-			err := wk.WalkDirectory(os.DirFS(location), location, recurse, files)
+			err := wk.WalkDirectory(os.DirFS(location), location, walkOptions, files)
 
 			if err != nil {
 				if isVerbose {

--- a/internal/smash/configuration.go
+++ b/internal/smash/configuration.go
@@ -38,6 +38,7 @@ func (app *App) printConfiguration() {
 	theme.Println(b.Sprint("Slicing:     "), theme.ColourConfig(enabledOrDisabled(!f.DisableSlicing)), config)
 	theme.Println(b.Sprint("Algorithm:   "), theme.ColourConfig(algorithms.Algorithm(f.Algorithm)))
 	theme.Println(b.Sprint("Locations:   "), theme.ColourConfig(strings.Join(app.Locations, ", ")))
+	theme.Println(b.Sprint("Recursive:   "), theme.ColourConfig(enabledOrDisabled(f.Recurse)))
 
 	if !f.HideOutput && f.OutputFile != "" {
 		theme.Println(b.Sprint("Output:      "), theme.ColourConfig(f.OutputFile), "(json)")

--- a/internal/smash/flags.go
+++ b/internal/smash/flags.go
@@ -20,6 +20,7 @@ type Flags struct {
 	IgnoreSystem    bool     `yaml:"ignore-system"`
 	ShowVersion     bool     `yaml:"version"`
 	ShowNerdStats   bool     `yaml:"nerd-stats"`
+	Recurse         bool     `yaml:"recurse"`
 	ShowDuplicates  bool     `yaml:"show-duplicates"`
 	Silent          bool     `yaml:"silent"`
 	HideTopList     bool     `yaml:"no-top-list"`

--- a/internal/smash/version.go
+++ b/internal/smash/version.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	Version = "v0.0.7"
+	Version = "v0.7.0"
 	Commit  = "none"
 	Date    = "unknown"
 	Time    = "nowish"

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -63,8 +63,9 @@ func NewConfigured(excludeDirFilter []string, excludeFileFilter []string, ignore
 	return indexer
 }
 
-func (config *IndexerConfig) WalkDirectory(f fs.FS, root string, files chan *FileFS) error {
-	walkErr := fs.WalkDir(f, ".", func(path string, d fs.DirEntry, err error) error {
+func (config *IndexerConfig) WalkDirectory(f fs.FS, root string, recurse bool, files chan *FileFS) error {
+	const RootDir = "."
+	walkErr := fs.WalkDir(f, RootDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			if errors.Is(err, fs.ErrPermission) {
 				return fs.SkipDir
@@ -79,8 +80,9 @@ func (config *IndexerConfig) WalkDirectory(f fs.FS, root string, files chan *Fil
 
 			isIgnoreDir := config.IgnoreSystemItems && config.isIgnored(name, config.excludeSysDirFilter)
 			isExludeDir := len(config.ExcludeDirFilter) > 0 && config.dirMatcher.MatchString(path)
+			dontRecurse := !recurse && name != RootDir
 
-			if isHiddenObj || isIgnoreDir || isExludeDir {
+			if isHiddenObj || isIgnoreDir || isExludeDir || dontRecurse {
 				return fs.SkipDir
 			}
 

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -28,6 +28,9 @@ type IndexerConfig struct {
 	IgnoreHiddenItems bool
 	IgnoreSystemItems bool
 }
+type WalkConfig struct {
+	Recurse bool
+}
 
 func New() *IndexerConfig {
 	return &IndexerConfig{
@@ -63,7 +66,7 @@ func NewConfigured(excludeDirFilter []string, excludeFileFilter []string, ignore
 	return indexer
 }
 
-func (config *IndexerConfig) WalkDirectory(f fs.FS, root string, recurse bool, files chan *FileFS) error {
+func (config *IndexerConfig) WalkDirectory(f fs.FS, root string, options WalkConfig, files chan *FileFS) error {
 	const RootDir = "."
 	walkErr := fs.WalkDir(f, RootDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -80,7 +83,7 @@ func (config *IndexerConfig) WalkDirectory(f fs.FS, root string, recurse bool, f
 
 			isIgnoreDir := config.IgnoreSystemItems && config.isIgnored(name, config.excludeSysDirFilter)
 			isExludeDir := len(config.ExcludeDirFilter) > 0 && config.dirMatcher.MatchString(path)
-			dontRecurse := !recurse && name != RootDir
+			dontRecurse := !options.Recurse && name != RootDir
 
 			if isHiddenObj || isIgnoreDir || isExludeDir || dontRecurse {
 				return fs.SkipDir

--- a/pkg/indexer/indexer_test.go
+++ b/pkg/indexer/indexer_test.go
@@ -11,8 +11,8 @@ func TestIndexDirectoryWithFilesInRoot(t *testing.T) {
 		"DSC19841.ARW",
 		"DSC19842.ARW",
 	}
-
-	walkedFiles := walkDirectoryTestRunner(mockFiles, nil, nil, true, true, t)
+	walkOptions := WalkConfig{Recurse: true}
+	walkedFiles := walkDirectoryTestRunner(mockFiles, nil, nil, true, walkOptions, t)
 
 	expected := mockFiles
 	actual := walkedFiles
@@ -35,7 +35,8 @@ func TestIndexDirectoryWithFilesAcrossFolders(t *testing.T) {
 		"subfolder-2/DSC19848.ARW",
 	}
 
-	walkedFiles := walkDirectoryTestRunner(mockFiles, nil, nil, true, true, t)
+	walkOptions := WalkConfig{Recurse: true}
+	walkedFiles := walkDirectoryTestRunner(mockFiles, nil, nil, true, walkOptions, t)
 
 	expected := mockFiles
 	actual := walkedFiles
@@ -62,7 +63,8 @@ func TestIndexDirectoryWithDirExclusionsNoRecurse(t *testing.T) {
 		"subfolder-2/DSC19848.ARW",
 	}
 
-	walkedFiles := walkDirectoryTestRunner(mockFiles, exclude_dir, exclude_file, true, false, t)
+	walkOptions := WalkConfig{Recurse: false}
+	walkedFiles := walkDirectoryTestRunner(mockFiles, exclude_dir, exclude_file, true, walkOptions, t)
 
 	expected := []string{
 		mockFiles[0],
@@ -92,7 +94,8 @@ func TestIndexDirectoryWithDirExclusions(t *testing.T) {
 		"subfolder-2/DSC19848.ARW",
 	}
 
-	walkedFiles := walkDirectoryTestRunner(mockFiles, exclude_dir, exclude_file, true, true, t)
+	walkOptions := WalkConfig{Recurse: true}
+	walkedFiles := walkDirectoryTestRunner(mockFiles, exclude_dir, exclude_file, true, walkOptions, t)
 
 	expected := []string{
 		mockFiles[0],
@@ -120,7 +123,8 @@ func TestIndexDirectoryWithFileExclusions(t *testing.T) {
 		"exclude.me",
 	}
 
-	walkedFiles := walkDirectoryTestRunner(mockFiles, exclude_dir, exclude_file, true, true, t)
+	walkOptions := WalkConfig{Recurse: true}
+	walkedFiles := walkDirectoryTestRunner(mockFiles, exclude_dir, exclude_file, true, walkOptions, t)
 
 	expected := []string{
 		mockFiles[0],
@@ -150,7 +154,8 @@ func TestIndexDirectoryWithFileAndDirExclusions(t *testing.T) {
 		"exclude-dir/random.file",
 	}
 
-	walkedFiles := walkDirectoryTestRunner(mockFiles, exclude_dir, exclude_file, true, true, t)
+	walkOptions := WalkConfig{Recurse: true}
+	walkedFiles := walkDirectoryTestRunner(mockFiles, exclude_dir, exclude_file, true, walkOptions, t)
 
 	expected := []string{
 		mockFiles[0],
@@ -179,7 +184,8 @@ func TestIndexDirectoryWithHiddenFilesThatShouldBeIndexed(t *testing.T) {
 		".config/smash/config.json",
 	}
 
-	walkedFiles := walkDirectoryTestRunner(mockFiles, exclude_dir, exclude_file, false, true, t)
+	walkOptions := WalkConfig{Recurse: true}
+	walkedFiles := walkDirectoryTestRunner(mockFiles, exclude_dir, exclude_file, false, walkOptions, t)
 
 	expected := []string{
 		mockFiles[3],
@@ -211,7 +217,8 @@ func TestIndexDirectoryWithHiddenFiles(t *testing.T) {
 		".config/smash/config.json",
 	}
 
-	walkedFiles := walkDirectoryTestRunner(mockFiles, exclude_dir, exclude_file, true, true, t)
+	walkOptions := WalkConfig{Recurse: true}
+	walkedFiles := walkDirectoryTestRunner(mockFiles, exclude_dir, exclude_file, true, walkOptions, t)
 
 	expected := []string{
 		mockFiles[0],
@@ -238,7 +245,8 @@ func TestIndexDirectoryWhichContainsSystemFiles(t *testing.T) {
 		"desktop.ini",
 	}
 
-	walkedFiles := walkDirectoryTestRunner(mockFiles, exclude_dir, exclude_file, true, true, t)
+	walkOptions := WalkConfig{Recurse: true}
+	walkedFiles := walkDirectoryTestRunner(mockFiles, exclude_dir, exclude_file, true, walkOptions, t)
 
 	expected := []string{
 		mockFiles[0],
@@ -265,7 +273,8 @@ func TestIndexDirectoryWhichContainsWindowsSystemFiles(t *testing.T) {
 		"$MFT/random.file",
 	}
 
-	walkedFiles := walkDirectoryTestRunner(mockFiles, exclude_dir, exclude_file, true, true, t)
+	walkOptions := WalkConfig{Recurse: true}
+	walkedFiles := walkDirectoryTestRunner(mockFiles, exclude_dir, exclude_file, true, walkOptions, t)
 
 	expected := []string{
 		mockFiles[0],
@@ -290,16 +299,16 @@ func channelFileToSliceOfFiles(ch <-chan *FileFS) []string {
 	return result
 }
 
-func walkDirectoryTestRunner(files []string, excludeDir []string, excludeFiles []string, ignoreHiddenItems bool, recursive bool, t *testing.T) []string {
+func walkDirectoryTestRunner(files []string, excludeDir []string, excludeFiles []string, ignoreHiddenItems bool, options WalkConfig, t *testing.T) []string {
 	fr := "mock://"
 	fs := createMockFS(files)
 	ch := make(chan *FileFS)
-	rc := recursive
+	wo := options
 
 	go func() {
 		defer close(ch)
 		indexer := NewConfigured(excludeDir, excludeFiles, ignoreHiddenItems, true)
-		err := indexer.WalkDirectory(fs, fr, rc, ch)
+		err := indexer.WalkDirectory(fs, fr, wo, ch)
 		if err != nil {
 			t.Errorf("WalkDirectory returned an error: %v", err)
 		}

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ Flags:
   -o, --output-file string     Export analysis as JSON (generated automatically otherwise)
       --profile                Enable Go Profiler - see localhost:1984/debug/pprof
       --progress-update int    Update progress every x seconds (default 5)
+  -r, --recurse                Recursively search directories for files
       --show-duplicates        Show full list of duplicates
       --show-top int           Show the top x duplicates (default 10)
   -q, --silent                 Run in silent mode
@@ -85,12 +86,18 @@ See the [full list of algorithms](./docs/algorithms.md) supported.
 
 Examples are given in Unix format, but apply to Windows as well.
 
+> \[!TIP]
+>
+> To recursively smash through directories, use the `--recursive` or `-r` switch.
+>
+> By default, `smash` will only look in the current folder (from v0.7+)
+
 ### Basic
 
 To check for duplicates in a single path (Eg. `~/media/photos`) & output report to `report.json`
 
 ```bash
-$ ./smash ~/media/photos -o report.json
+$ ./smash ~/media/photos -r -o report.json
 ```
 
 You can then look at `report.json` with [jq](https://github.com/jqlang/jq) to check duplicates:
@@ -104,7 +111,7 @@ $ jq '.analysis.dupes[]|[.location,.path,.filename]|join("/")' report.json | xar
 By default, `smash` ignores empty files but can report on them with the `--ignore-empty=false` argument:
 
 ```bash
-$ ./smash ~/media/photos --ignore-empty=false -o report.json
+$ ./smash ~/media/photos -r --ignore-empty=false -o report.json
 ```
 
 You can then look at `report.json` with [jq](https://github.com/jqlang/jq) to check empty files:
@@ -118,7 +125,7 @@ $ jq '.analysis.empty[]|[.location,.path,.filename]|join("/")' report.json | xar
 By default, `smash` shows the top 10 duplicate files in the CLI and leaves the rest for the report, you can change that with the `--show-top=50` argument to show the top 50 instead.
 
 ```bash
-$ ./smash ~/media/photos --show-top=50
+$ ./smash ~/media/photos -r --show-top=50
 ```
 
 ### Multiple Directories
@@ -136,13 +143,13 @@ Smash will find and report all duplicates within any number of directories passe
 You can exclude certain directories or files with the `--exclude-dir` and `--exclude-file` switches including wildcard characters:
 
 ```bash
-$ ./smash --exclude-dir=.git,.svn --exclude-file=.gitignore,*.csv ~/media/photos
+$ ./smash -r --exclude-dir=.git,.svn --exclude-file=.gitignore,*.csv ~/media/photos
 ```
 
 For example, to ignore all hidden files on unix (those that start with `.` such as `.config` or `.gnome` folders):
 
 ```bash
-$ ./smash --exclude-dir=.config,.gnome ~/media/photos
+$ ./smash -r --exclude-dir=.config,.gnome ~/media/photos
 ```
 
 ### Disabling Slicing & Getting Full Hash
@@ -152,7 +159,7 @@ By default, `smash` uses slicing to efficiently slice a file into mulitple segme
 If you prefer not to use slicing for a run, you can disable slicing with:
 
 ```bash
-$ ./smash --disable-slicing ~/media/photos
+$ ./smash -r --disable-slicing ~/media/photos
 ```
 
 ### Changing Hashing Algorithms
@@ -163,7 +170,7 @@ of algorithms [as documented](./docs/algorithms.md).
 To use another supported algorithm, use the `--algorithm` switch:
 
 ```bash
-$ ./smash --algorithm:murmur3 ~/media/photos
+$ ./smash -r --algorithm:murmur3 ~/media/photos
 ```
 
 # Acknowledgements


### PR DESCRIPTION
This PR breaks previous releases in that one needs to specify `-r` or `--recurse` to walk subdirs.

Solves issues with only wanting to root folder and no subfolders without specifying them all in `--exclude-dir` as a workaround.