### PR TITLE
BUG: Fixing named pipes and socket files on unix

### DIFF
--- a/pkg/slicer/slicer.go
+++ b/pkg/slicer/slicer.go
@@ -3,10 +3,11 @@ package slicer
 import (
 	"encoding/gob"
 	"errors"
-	"github.com/thushan/smash/internal/algorithms"
 	"io"
 	"io/fs"
 	"os"
+
+	"github.com/thushan/smash/internal/algorithms"
 )
 
 type Slicer struct {
@@ -245,5 +246,7 @@ func shouldAnalyseBasedOnSize(fileSize, minSize, maxSize uint64) bool {
 }
 func shouldIgnoreFileMode(fio os.FileInfo) bool {
 	return fio.Mode()&os.ModeNamedPipe != 0 ||
-		fio.Mode()&os.ModeSocket != 0
+		fio.Mode()&os.ModeSocket != 0 ||
+		fio.Mode()&os.ModeDevice != 0 ||
+		fio.Mode()&os.ModeSymlink != 0
 }


### PR DESCRIPTION
This PR addresses #61 to ignore invalid files - such as named pipes, socket files etc, that should be ignored during a run.

